### PR TITLE
Support when multiple source files are including this header lib

### DIFF
--- a/include/matplotlibcpp17/animation.h
+++ b/include/matplotlibcpp17/animation.h
@@ -2,9 +2,7 @@
  * @file animation.h
  * @brief corresponding header for matplotlib.animation
  **/
-
-#ifndef MATPLOTLIBCPP17_ANIMATION_H
-#define MATPLOTLIBCPP17_ANIMATION_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -40,5 +38,3 @@ ObjectWrapper ArtistAnimation::save(const pybind11::tuple &args,
 }
 
 } // namespace matplotlibcpp17::animation
-
-#endif /* MATPLOTLIBCPP17_ANIMATION_H */

--- a/include/matplotlibcpp17/axes.h
+++ b/include/matplotlibcpp17/axes.h
@@ -2,15 +2,13 @@
  * @file axes.h
  * @brief corresponding header for matplotlib.axes
  **/
+#pragma once
 
-#ifndef MATPLOTLIBCPP17_AXES_H
-#define MATPLOTLIBCPP17_AXES_H
-
-#include <vector>
 #include <tuple>
+#include <vector>
 
-#include <matplotlibcpp17/common.h>
 #include <matplotlibcpp17/collections.h>
+#include <matplotlibcpp17/common.h>
 #include <matplotlibcpp17/container.h>
 #include <matplotlibcpp17/legend.h>
 #include <matplotlibcpp17/quiver.h>
@@ -361,50 +359,50 @@ private:
 };
 
 // add_artist
-ObjectWrapper Axes::add_artist(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::add_artist(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = add_artist_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // add_collection
-ObjectWrapper Axes::add_collection(const pybind11::tuple &args,
-                                   const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::add_collection(const pybind11::tuple &args,
+                                          const pybind11::dict &kwargs) {
   pybind11::object ret = add_collection_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // add_patch
-ObjectWrapper Axes::add_patch(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::add_patch(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object ret = add_patch_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // axhline
-ObjectWrapper Axes::axhline(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::axhline(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object ret = axhline_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // axvline
-ObjectWrapper Axes::axvline(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::axvline(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object ret = axvline_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // bar
-container::BarContainer Axes::bar(const pybind11::tuple &args,
-                                  const pybind11::dict &kwargs) {
+inline container::BarContainer Axes::bar(const pybind11::tuple &args,
+                                         const pybind11::dict &kwargs) {
   pybind11::object obj = bar_attr(*args, **kwargs);
   return container::BarContainer(obj);
 }
 
 // bar_label
-ObjectWrapper Axes::bar_label(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::bar_label(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
 #if MATPLOTLIB_MINOR_VER_GTE_4
   pybind11::object ret = bar_label_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
@@ -416,36 +414,36 @@ ObjectWrapper Axes::bar_label(const pybind11::tuple &args,
 }
 
 // barh
-container::BarContainer Axes::barh(const pybind11::tuple &args,
-                                   const pybind11::dict &kwargs) {
+inline container::BarContainer Axes::barh(const pybind11::tuple &args,
+                                          const pybind11::dict &kwargs) {
   pybind11::object obj = barh_attr(*args, **kwargs);
   return container::BarContainer(obj);
 }
 
 // cla
-ObjectWrapper Axes::cla(const pybind11::tuple &args,
-                        const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::cla(const pybind11::tuple &args,
+                               const pybind11::dict &kwargs) {
   pybind11::object ret = cla_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // contour
-ObjectWrapper Axes::contour(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::contour(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object ret = contour_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // contourf
-ObjectWrapper Axes::contourf(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::contourf(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = contourf_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // errorbar
-ObjectWrapper Axes::errorbar(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::errorbar(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   if (projection_3d) {
 #if MATPLOTLIB_MINOR_VER_GTE_4
     pybind11::object obj = errorbar_attr(*args, **kwargs);
@@ -462,42 +460,42 @@ ObjectWrapper Axes::errorbar(const pybind11::tuple &args,
 }
 
 // fill
-ObjectWrapper Axes::fill(const pybind11::tuple &args,
-                         const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::fill(const pybind11::tuple &args,
+                                const pybind11::dict &kwargs) {
   pybind11::object ret = fill_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // fill_between
-ObjectWrapper Axes::fill_between(const pybind11::tuple &args,
-                                 const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::fill_between(const pybind11::tuple &args,
+                                        const pybind11::dict &kwargs) {
   pybind11::object ret = fill_between_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // fill_betweenx
-ObjectWrapper Axes::fill_betweenx(const pybind11::tuple &args,
-                                  const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::fill_betweenx(const pybind11::tuple &args,
+                                         const pybind11::dict &kwargs) {
   pybind11::object ret = fill_betweenx_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // get_lines
-ObjectWrapper Axes::get_lines(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::get_lines(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object ret = get_lines_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // get_xaxis_transform
-ObjectWrapper Axes::get_xaxis_transform(const pybind11::tuple &args,
-                                        const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::get_xaxis_transform(const pybind11::tuple &args,
+                                               const pybind11::dict &kwargs) {
   pybind11::object ret = get_xaxis_transform_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // get_xlim
-std::tuple<double, double> Axes::get_xlim() {
+inline std::tuple<double, double> Axes::get_xlim() {
   pybind11::list ret = get_xlim_attr();
   double x1 = ret[0].cast<double>();
   double x2 = ret[1].cast<double>();
@@ -505,7 +503,7 @@ std::tuple<double, double> Axes::get_xlim() {
 }
 
 // get_xticklabels
-std::vector<text::Text> Axes::get_xticklabels() {
+inline std::vector<text::Text> Axes::get_xticklabels() {
   pybind11::list ret = get_xticklabels_attr();
   std::vector<text::Text> texts;
   for (pybind11::size_t i = 0; i < ret.size(); ++i) {
@@ -515,14 +513,15 @@ std::vector<text::Text> Axes::get_xticklabels() {
 }
 
 // grid
-ObjectWrapper Axes::grid(const pybind11::tuple &args,
-                         const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::grid(const pybind11::tuple &args,
+                                const pybind11::dict &kwargs) {
   pybind11::object ret = grid_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // hist
-std::tuple<std::vector<double>, std::vector<double>, container::BarContainer>
+inline std::tuple<std::vector<double>, std::vector<double>,
+                  container::BarContainer>
 Axes::hist(const pybind11::tuple &args, const pybind11::dict &kwargs) {
   pybind11::list ret = hist_attr(*args, **kwargs);
   // parse N, bins, patches
@@ -539,207 +538,206 @@ Axes::hist(const pybind11::tuple &args, const pybind11::dict &kwargs) {
 }
 
 // hist2d
-ObjectWrapper Axes::hist2d(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::hist2d(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = hist2d_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // invert_yaxis
-ObjectWrapper Axes::invert_yaxis(const pybind11::tuple &args,
-                                 const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::invert_yaxis(const pybind11::tuple &args,
+                                        const pybind11::dict &kwargs) {
   pybind11::object ret = invert_yaxis_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // imshow
-ObjectWrapper Axes::imshow(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::imshow(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = imshow_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // legend
-legend::Legend Axes::legend(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline legend::Legend Axes::legend(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object obj = legend_attr(*args, **kwargs);
   return legend::Legend(obj);
 }
 
 // pcolormesh
-collections::QuadMesh Axes::pcolormesh(const pybind11::tuple &args,
-                                       const pybind11::dict &kwargs) {
+inline collections::QuadMesh Axes::pcolormesh(const pybind11::tuple &args,
+                                              const pybind11::dict &kwargs) {
   pybind11::object ret = pcolormesh_attr(*args, **kwargs);
   return collections::QuadMesh(ret);
 }
 
 // plot
-ObjectWrapper Axes::plot(const pybind11::tuple &args,
-                         const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::plot(const pybind11::tuple &args,
+                                const pybind11::dict &kwargs) {
   pybind11::object ret = plot_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // plot_surface
-ObjectWrapper Axes::plot_surface(const pybind11::tuple &args,
-                                 const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::plot_surface(const pybind11::tuple &args,
+                                        const pybind11::dict &kwargs) {
   pybind11::object ret = plot_surface_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // plot_wireframe
-ObjectWrapper Axes::plot_wireframe(const pybind11::tuple &args,
-                                   const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::plot_wireframe(const pybind11::tuple &args,
+                                          const pybind11::dict &kwargs) {
   pybind11::object ret = plot_wireframe_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // quiver
-quiver::Quiver Axes::quiver(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline quiver::Quiver Axes::quiver(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object obj = quiver_attr(*args, **kwargs);
   return quiver::Quiver(obj);
 }
 
 // quiverkey
-quiver::QuiverKey Axes::quiverkey(const pybind11::tuple &args,
-                                  const pybind11::dict &kwargs) {
+inline quiver::QuiverKey Axes::quiverkey(const pybind11::tuple &args,
+                                         const pybind11::dict &kwargs) {
   pybind11::object obj = quiverkey_attr(*args, **kwargs);
   return quiver::QuiverKey(obj);
 }
 
 // scatter
-collections::PathCollection Axes::scatter(const pybind11::tuple &args,
-                                          const pybind11::dict &kwargs) {
+inline collections::PathCollection Axes::scatter(const pybind11::tuple &args,
+                                                 const pybind11::dict &kwargs) {
   pybind11::object obj = scatter_attr(*args, **kwargs);
   return collections::PathCollection(obj);
 }
 
 // set
-ObjectWrapper Axes::set(const pybind11::tuple &args,
-                        const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set(const pybind11::tuple &args,
+                               const pybind11::dict &kwargs) {
   pybind11::object ret = set_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_adjustable
-ObjectWrapper Axes::set_adjustable(const pybind11::tuple &args,
-                                   const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_adjustable(const pybind11::tuple &args,
+                                          const pybind11::dict &kwargs) {
   pybind11::object ret = set_adjustable_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_aspect
-ObjectWrapper Axes::set_aspect(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_aspect(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_aspect_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_title
-ObjectWrapper Axes::set_title(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_title(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object ret = set_title_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_xlabel
-ObjectWrapper Axes::set_xlabel(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_xlabel(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_xlabel_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_xlim
-ObjectWrapper Axes::set_xlim(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_xlim(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = set_xlim_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_xscale
-ObjectWrapper Axes::set_xscale(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_xscale(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_xscale_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_xticks
-ObjectWrapper Axes::set_xticks(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_xticks(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_xticks_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_xticklabels
-ObjectWrapper Axes::set_xticklabels(const pybind11::tuple &args,
-                                    const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_xticklabels(const pybind11::tuple &args,
+                                           const pybind11::dict &kwargs) {
   pybind11::object ret = set_xticklabels_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_ylabel
-ObjectWrapper Axes::set_ylabel(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_ylabel(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_ylabel_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_ylim
-ObjectWrapper Axes::set_ylim(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_ylim(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = set_ylim_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_yscale
-ObjectWrapper Axes::set_yscale(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_yscale(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_yscale_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_yticks
-ObjectWrapper Axes::set_yticks(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_yticks(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_yticks_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_zlabel
-ObjectWrapper Axes::set_zlabel(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_zlabel(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = set_zlabel_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // set_zlim
-ObjectWrapper Axes::set_zlim(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::set_zlim(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = set_zlim_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // text
-ObjectWrapper Axes::text(const pybind11::tuple &args,
-                         const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::text(const pybind11::tuple &args,
+                                const pybind11::dict &kwargs) {
   pybind11::object ret = text_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // tick_params
-ObjectWrapper Axes::tick_params(const pybind11::tuple &args,
-                                const pybind11::dict &kwargs) {
+inline ObjectWrapper Axes::tick_params(const pybind11::tuple &args,
+                                       const pybind11::dict &kwargs) {
   pybind11::object ret = tick_params_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // twinx
-Axes Axes::twinx(const pybind11::tuple &args, const pybind11::dict &kwargs) {
+inline Axes Axes::twinx(const pybind11::tuple &args,
+                        const pybind11::dict &kwargs) {
   pybind11::object ret = twinx_attr(*args, **kwargs);
   return Axes(ret);
 }
 
 } // namespace matplotlibcpp17::axes
-
-#endif /* MATPLOTLIBCPP17_AXES_H */

--- a/include/matplotlibcpp17/cm.h
+++ b/include/matplotlibcpp17/cm.h
@@ -2,9 +2,7 @@
  * @file cm.h
  * @brief corresponding header for matplotlib.cm
  **/
-
-#ifndef MATPLOTLIBCPP17_CM_H
-#define MATPLOTLIBCPP17_CM_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -16,5 +14,3 @@ static const char *PuBu_r = "PuBu_r";
 static const char *RdYlGn = "RdYlGn";
 
 } // namespace matplotlibcpp17::cm
-
-#endif /* MATPLOTLIBCPP17_CM_H */

--- a/include/matplotlibcpp17/collections.h
+++ b/include/matplotlibcpp17/collections.h
@@ -2,9 +2,7 @@
  * @file collections.h
  * @brief corresponding header for matplotlib.collections
  **/
-
-#ifndef MATPLOTLIBCPP17_COLLECTIONS_H
-#define MATPLOTLIBCPP17_COLLECTIONS_H
+#pragma once
 
 #include <utility>
 
@@ -41,7 +39,7 @@ private:
 // legend_elements
 /// NOTE: this func does not return list of Line2Ds(handles) and list of
 /// strs(labels) unlike original python func
-std::pair<ObjectWrapper, ObjectWrapper>
+inline std::pair<ObjectWrapper, ObjectWrapper>
 PathCollection::legend_elements(const pybind11::tuple &args,
                                 const pybind11::dict &kwargs) {
   pybind11::list ret = legend_elements_attr(*args, **kwargs);
@@ -72,8 +70,8 @@ private:
   pybind11::object set_array_attr;
 };
 
-ObjectWrapper PatchCollection::set_array(const pybind11::tuple &args,
-                                         const pybind11::dict &kwargs) {
+inline ObjectWrapper PatchCollection::set_array(const pybind11::tuple &args,
+                                                const pybind11::dict &kwargs) {
   pybind11::object ret = set_array_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
@@ -88,5 +86,3 @@ public:
 };
 
 } // namespace matplotlibcpp17::collections
-
-#endif /* MATPLOTLIBCPP17_COLLECTIONS_H */

--- a/include/matplotlibcpp17/common.h
+++ b/include/matplotlibcpp17/common.h
@@ -1,5 +1,5 @@
-#ifndef MATPLOTLIBCPP17_COMMON_H
-#define MATPLOTLIBCPP17_COMMON_H
+#pragma once
+
 
 #define LOAD_FUNC_ATTR(obj, mod)                                               \
   do {                                                                         \
@@ -54,5 +54,3 @@ public:
 };
 
 } // namespace matplotlibcpp17
-
-#endif /* MATPLOTLIBCPP17_COMMON_H */

--- a/include/matplotlibcpp17/container.h
+++ b/include/matplotlibcpp17/container.h
@@ -2,9 +2,7 @@
  * @file container.h
  * @brief corresponding header for matplotlib.axes
  **/
-
-#ifndef MATPLOTLIBCPP17_CONTAINER_H
-#define MATPLOTLIBCPP17_CONTAINER_H
+#pragma once
 
 #include <matplotlibcpp17/common.h>
 
@@ -24,5 +22,3 @@ public:
 };
 
 } // namespace matplotlibcpp17::container
-
-#endif /* MATPLOTLIBCPP17_CONTAINER_H */

--- a/include/matplotlibcpp17/figure.h
+++ b/include/matplotlibcpp17/figure.h
@@ -2,12 +2,10 @@
  * @file figure.h
  * @brief corresponding header for matplotlib.figure
  **/
+#pragma once
 
-#ifndef MATPLOTLIBCPP17_FIGURE_H
-#define MATPLOTLIBCPP17_FIGURE_H
-
-#include <matplotlibcpp17/common.h>
 #include <matplotlibcpp17/axes.h>
+#include <matplotlibcpp17/common.h>
 #include <matplotlibcpp17/gridspec.h>
 
 #include <pybind11/pybind11.h>
@@ -82,60 +80,58 @@ private:
 };
 
 // add_axes
-axes::Axes Figure::add_axes(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline axes::Axes Figure::add_axes(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object obj = add_axes_attr(*args, **kwargs);
   return axes::Axes(obj);
 }
 
 // add_gridspec
-gridspec::GridSpec Figure::add_gridspec(int nrow, int ncol,
-                                        const pybind11::dict &kwargs) {
+inline gridspec::GridSpec Figure::add_gridspec(int nrow, int ncol,
+                                               const pybind11::dict &kwargs) {
   return gridspec::GridSpec(nrow, ncol, kwargs);
 }
 
 // add_subplot
-axes::Axes Figure::add_subplot(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline axes::Axes Figure::add_subplot(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object obj = add_subplot_attr(*args, **kwargs);
   return axes::Axes(obj);
 }
 
 // align_labels
-ObjectWrapper Figure::align_labels(const pybind11::tuple &args,
-                                   const pybind11::dict &kwargs) {
+inline ObjectWrapper Figure::align_labels(const pybind11::tuple &args,
+                                          const pybind11::dict &kwargs) {
   pybind11::object ret = align_labels_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // colorbar
-ObjectWrapper Figure::colorbar(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Figure::colorbar(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = colorbar_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // savefig
-ObjectWrapper Figure::savefig(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper Figure::savefig(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object ret = savefig_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // suptitle
-ObjectWrapper Figure::suptitle(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper Figure::suptitle(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = suptitle_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // tight_layout
-ObjectWrapper Figure::tight_layout(const pybind11::tuple &args,
-                                   const pybind11::dict &kwargs) {
+inline ObjectWrapper Figure::tight_layout(const pybind11::tuple &args,
+                                          const pybind11::dict &kwargs) {
   pybind11::object ret = tight_layout_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 } // namespace matplotlibcpp17::figure
-
-#endif /* MATPLOTLIBCPP17_FIGURE_H */

--- a/include/matplotlibcpp17/gridspec.h
+++ b/include/matplotlibcpp17/gridspec.h
@@ -2,9 +2,7 @@
  * @file gridspec.h
  * @brief corresponding header for matplotlib.axes
  **/
-
-#ifndef MATPLOTLIBCPP17_GRIDSPEC_H
-#define MATPLOTLIBCPP17_GRIDSPEC_H
+#pragma once
 
 #include <matplotlibcpp17/common.h>
 
@@ -46,5 +44,3 @@ private:
 };
 
 } // namespace matplotlibcpp17::gridspec
-
-#endif /* MATPLOTLIBCPP17_GRIDSPEC_H */

--- a/include/matplotlibcpp17/legend.h
+++ b/include/matplotlibcpp17/legend.h
@@ -2,9 +2,7 @@
  * @file legend.h
  * @brief corresponding header for matplotlib.legend
  **/
-
-#ifndef MATPLOTLIBCPP17_LEGEND_H
-#define MATPLOTLIBCPP17_LEGEND_H
+#pragma once
 
 #include <matplotlibcpp17/common.h>
 
@@ -22,5 +20,3 @@ public:
 };
 
 } // namespace matplotlibcpp17::legend
-
-#endif /* MATPLOTLIBCPP17_LEGEND_H */

--- a/include/matplotlibcpp17/mplot3d.h
+++ b/include/matplotlibcpp17/mplot3d.h
@@ -2,9 +2,7 @@
  * @file mplot3d.h
  * @brief header file for mplot3d
  **/
-
-#ifndef MATPLOTLIBCPP17_MPLOT3D_H
-#define MATPLOTLIBCPP17_MPLOT3D_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -15,4 +13,3 @@ pybind11::object import() {
 }
 
 } // namespace matplotlibcpp17::mplot3d
-#endif

--- a/include/matplotlibcpp17/patches.h
+++ b/include/matplotlibcpp17/patches.h
@@ -2,9 +2,7 @@
  * @file pathces.h
  * @brief corresponding header for matplotlib.patches
  **/
-
-#ifndef MATPLOTLIBCPP17_PATCHES_H
-#define MATPLOTLIBCPP17_PATCHES_H
+#pragma once
 
 #include <matplotlibcpp17/common.h>
 
@@ -91,5 +89,3 @@ private:
 };
 
 } // namespace matplotlibcpp17::patches
-
-#endif /* MATPLOTLIBCPP17_PATCHES_H */

--- a/include/matplotlibcpp17/pyplot.h
+++ b/include/matplotlibcpp17/pyplot.h
@@ -2,20 +2,18 @@
  * @file pyplot.h
  * @brief corresponding header for matplotlib.pyplot
  **/
-
-#ifndef MATPLOTLIBCPP17_PYPLOT_H
-#define MATPLOTLIBCPP17_PYPLOT_H
+#pragma once
 
 #include <tuple>
 
-#include <matplotlibcpp17/common.h>
 #include <matplotlibcpp17/axes.h>
+#include <matplotlibcpp17/common.h>
 #include <matplotlibcpp17/figure.h>
 
-#include <pybind11/pybind11.h>
 #include <pybind11/embed.h>
-#include <pybind11/stl.h>
 #include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace matplotlibcpp17::pyplot {
 
@@ -212,56 +210,56 @@ private:
 };
 
 // axes
-axes::Axes PyPlot::axes(const pybind11::dict &kwargs) {
+inline axes::Axes PyPlot::axes(const pybind11::dict &kwargs) {
   pybind11::object ax_obj = axes_attr(**kwargs);
   return axes::Axes(ax_obj);
 }
 
 // axis
-ObjectWrapper PyPlot::axis(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::axis(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = axis_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // cla
-ObjectWrapper PyPlot::cla(const pybind11::tuple &args,
-                          const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::cla(const pybind11::tuple &args,
+                                 const pybind11::dict &kwargs) {
   pybind11::object ret = cla_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // clf
-ObjectWrapper PyPlot::clf(const pybind11::tuple &args,
-                          const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::clf(const pybind11::tuple &args,
+                                 const pybind11::dict &kwargs) {
   pybind11::object ret = clf_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // clim
-ObjectWrapper PyPlot::clim(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::clim(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = clim_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // colorbar
-ObjectWrapper PyPlot::colorbar(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::colorbar(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = colorbar_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // errorbar
-ObjectWrapper PyPlot::errorbar(const pybind11::tuple &args,
-                               const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::errorbar(const pybind11::tuple &args,
+                                      const pybind11::dict &kwargs) {
   pybind11::object ret = errorbar_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // figaspect
-std::tuple<double, double> PyPlot::figaspect(const pybind11::tuple &args,
-                                             const pybind11::dict &kwargs) {
+inline std::tuple<double, double>
+PyPlot::figaspect(const pybind11::tuple &args, const pybind11::dict &kwargs) {
   pybind11::list l = figaspect_attr(*args, **kwargs);
   double width = l[0].cast<double>();
   double height = l[1].cast<double>();
@@ -269,115 +267,115 @@ std::tuple<double, double> PyPlot::figaspect(const pybind11::tuple &args,
 }
 
 // figure
-figure::Figure PyPlot::figure(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline figure::Figure PyPlot::figure(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object fig_obj = figure_attr(*args, **kwargs);
   return figure::Figure(fig_obj);
 }
 
 // gca
-axes::Axes PyPlot::gca(const pybind11::tuple &args,
-                       const pybind11::dict &kwargs) {
+inline axes::Axes PyPlot::gca(const pybind11::tuple &args,
+                              const pybind11::dict &kwargs) {
   pybind11::object obj = gca_attr(*args, **kwargs);
   return axes::Axes(obj);
 }
 
 // gcf
-figure::Figure PyPlot::gcf(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline figure::Figure PyPlot::gcf(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object obj = gcf_attr(*args, **kwargs);
   return figure::Figure(obj);
 }
 
 // gci
-ObjectWrapper PyPlot::gci(const pybind11::tuple &args,
-                          const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::gci(const pybind11::tuple &args,
+                                 const pybind11::dict &kwargs) {
   pybind11::object obj = gci_attr(*args, **kwargs);
   return obj;
 }
 
 // grid
-ObjectWrapper PyPlot::grid(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::grid(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object obj = grid_attr(*args, **kwargs);
   return obj;
 }
 
 // imshow
-ObjectWrapper PyPlot::imshow(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::imshow(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object obj = imshow_attr(*args, **kwargs);
   return obj;
 }
 
 // legend
-ObjectWrapper PyPlot::legend(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::legend(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = legend_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // pause
-ObjectWrapper PyPlot::pause(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::pause(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object ret = pause_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // plot
-ObjectWrapper PyPlot::plot(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::plot(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = plot_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // quiver
-ObjectWrapper PyPlot::quiver(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::quiver(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = quiver_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // scatter
-ObjectWrapper PyPlot::scatter(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::scatter(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object ret = scatter_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // savefig
-ObjectWrapper PyPlot::savefig(const pybind11::tuple &args,
-                              const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::savefig(const pybind11::tuple &args,
+                                     const pybind11::dict &kwargs) {
   pybind11::object ret = savefig_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // show
-ObjectWrapper PyPlot::show(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::show(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = show_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // step
-ObjectWrapper PyPlot::step(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::step(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = step_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // subplot
-axes::Axes PyPlot::subplot(const pybind11::dict &kwargs) {
+inline axes::Axes PyPlot::subplot(const pybind11::dict &kwargs) {
   return axes::Axes(subplot_attr(**kwargs));
 }
 
-axes::Axes PyPlot::subplot(int cri) {
+inline axes::Axes PyPlot::subplot(int cri) {
   pybind11::object obj = subplot_attr(cri);
   return axes::Axes(obj);
 }
 
 // subplots
-std::tuple<figure::Figure, axes::Axes>
+inline std::tuple<figure::Figure, axes::Axes>
 PyPlot::subplots(const pybind11::dict &kwargs) {
   pybind11::list ret = subplots_attr(**kwargs);
   pybind11::object fig = ret[0];
@@ -385,7 +383,7 @@ PyPlot::subplots(const pybind11::dict &kwargs) {
   return {figure::Figure(fig), axes::Axes(ax)};
 }
 
-std::tuple<figure::Figure, std::vector<axes::Axes>>
+inline std::tuple<figure::Figure, std::vector<axes::Axes>>
 PyPlot::subplots(int r, int c, const pybind11::dict &kwargs) {
   // subplots() returns [][] (if r > 1 && c > 1) else []
   // return []axes in row-major
@@ -416,41 +414,41 @@ PyPlot::subplots(int r, int c, const pybind11::dict &kwargs) {
 }
 
 // title
-ObjectWrapper PyPlot::title(const pybind11::tuple &args,
-                            const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::title(const pybind11::tuple &args,
+                                   const pybind11::dict &kwargs) {
   pybind11::object ret = title_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // xlabel
-ObjectWrapper PyPlot::xlabel(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::xlabel(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = xlabel_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // xlim
-ObjectWrapper PyPlot::xlim(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::xlim(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = xlim_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // ylabel
-ObjectWrapper PyPlot::ylabel(const pybind11::tuple &args,
-                             const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::ylabel(const pybind11::tuple &args,
+                                    const pybind11::dict &kwargs) {
   pybind11::object ret = ylabel_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 // ylim
-ObjectWrapper PyPlot::ylim(const pybind11::tuple &args,
-                           const pybind11::dict &kwargs) {
+inline ObjectWrapper PyPlot::ylim(const pybind11::tuple &args,
+                                  const pybind11::dict &kwargs) {
   pybind11::object ret = ylim_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
-PyPlot import() {
+inline PyPlot import() {
   auto mod = pybind11::module::import("matplotlib.pyplot");
   auto g_pyplot = PyPlot(mod);
   return g_pyplot;
@@ -468,5 +466,3 @@ using Kwargs = pybind11::dict;
 // Export this
 namespace py = pybind11;
 using namespace py::literals;
-
-#endif /* MATPLOTLIBCPP17_PYPLOT_H */

--- a/include/matplotlibcpp17/quiver.h
+++ b/include/matplotlibcpp17/quiver.h
@@ -2,9 +2,7 @@
  * @file quiver.h
  * @brief corresponding header for matplotlib.quiver
  **/
-
-#ifndef MATPLOTLIBCPP17_QUIVER_H
-#define MATPLOTLIBCPP17_QUIVER_H
+#pragma once
 
 #include <matplotlibcpp17/common.h>
 
@@ -30,5 +28,3 @@ struct DECL_STRUCT_ATTR QuiverKey : public BaseWrapper {
 };
 
 } // namespace matplotlibcpp17::quiver
-
-#endif /* MATPLOTLIBCPP17_QUIVER_H */

--- a/include/matplotlibcpp17/text.h
+++ b/include/matplotlibcpp17/text.h
@@ -2,9 +2,7 @@
  * @file text.h
  * @brief corresponding header for matplotlib.text
  **/
-
-#ifndef MATPLOTLIBCPP17_TEXT_H
-#define MATPLOTLIBCPP17_TEXT_H
+#pragma once
 
 #include <matplotlibcpp17/common.h>
 
@@ -34,12 +32,10 @@ private:
   pybind11::object set_rotation_attr;
 };
 
-ObjectWrapper Text::set_rotation(const pybind11::tuple &args,
-                                 const pybind11::dict &kwargs) {
+inline ObjectWrapper Text::set_rotation(const pybind11::tuple &args,
+                                        const pybind11::dict &kwargs) {
   pybind11::object ret = set_rotation_attr(*args, **kwargs);
   return ObjectWrapper(std::move(ret));
 }
 
 } // namespace matplotlibcpp17::text
-
-#endif /* MATPLOTLIBCPP17_TEXT_H */

--- a/include/matplotlibcpp17/ticker.h
+++ b/include/matplotlibcpp17/ticker.h
@@ -2,9 +2,7 @@
  * @file ticker.h
  * @brief corresponding header for matplotlib.ticker
  **/
-
-#ifndef MATPLOTLIBCPP17_TICKER_H
-#define MATPLOTLIBCPP17_TICKER_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -22,5 +20,3 @@ public:
 };
 
 } // namespace matplotlibcpp17::ticker
-
-#endif /* MATPLOTLIBCPP17_ANIMATION_H */


### PR DESCRIPTION
Replaced include guards with #pragma once

Defined all functions with inline specifier to support when multiple source files are including this header lib in the same project